### PR TITLE
Text changes and minor place name form improvements

### DIFF
--- a/scar-gazetteer/src/App.vue
+++ b/scar-gazetteer/src/App.vue
@@ -2,20 +2,11 @@
   <b-container fluid="sm">
     <b-container id="header">
       <b-row>
-        <b-col><img src="~@/assets/scar_logo_sm.gif" alt="S C A R" /></b-col>
+        <b-col><a href="https://scar.org"><img src="~@/assets/scar_logo_sm.gif" alt="S C A R" /></a></b-col>
         <b-col>
           <h1>SCAR COMPOSITE GAZETTEER OF ANTARCTICA</h1>
-          <h2>ENEA - P.N.R.A.</h2>
         </b-col>
         <b-col></b-col>
-      </b-row>
-      <b-row>
-        <p>
-          <a href="http://www.scar.org">Scientific Committee on Antarctic Research (SCAR)</a><br />
-          Collated by <a href="http://www.pnra.aq">Programma Nazionale di Ricerche in Antartide</a> (Italy)<br/>
-          in the framework of the SCAR <a href="http://www.scar.org/data-products/scagi">Standing Committee on Antarctic
-            Geographic Information (SCAGI)</a>
-        </p>
       </b-row>
     </b-container>
 
@@ -82,7 +73,7 @@
 
     <router-view />
     <div class="footer">
-      <p><i>The SCAR CGA was initially compiled by Roberto Cervellati and Chiara Ramorino from the Italian Antarctic names committee - Comitato per i nomi geografici antartici and still maintained by Italian representatives.</i></p>
+      <p><i>The SCAR CGA is edited by Italian representatives from Comitato per i nomi geografici antartici.</i></p>
       <p><i>The SCAR CGA is hosted by the <a href="https://data.aad.gov.au">Australian Antarctic Data Centre</a>.</i></p>
     </div>
   </b-container>

--- a/scar-gazetteer/src/components/PlaceNameForm.vue
+++ b/scar-gazetteer/src/components/PlaceNameForm.vue
@@ -53,11 +53,11 @@
                 :state="validateState('altitude_accuracy')" />
         </b-form-group>
         <b-form-group label="Narrative:" label-for="narrative" class="my-1">
-            <small>Use [L]&lt;placename&gt;[/L] to link to other place names.</small>
+            <small>Use <i>[L]&lt;placename&gt;[/L]</i> to link to other place names.</small>
             <b-form-textarea id="narrative" v-model="$v.form_data.narrative.$model" rows="3" max-rows="6" />
         </b-form-group>
         <b-form-group label="Narrative Translation:" label-for="narrative_translation" class="my-1">
-            <small>Use [L]&lt;placename&gt;[/L] to link to other place names.</small>
+            <small>Use <i>[L]&lt;placename&gt;[/L]</i> to link to other place names.</small>
             <b-form-textarea id="narrative_translation" v-model="$v.form_data.narrative_translation.$model" rows="3"
                 max-rows="6" />
         </b-form-group>
@@ -72,7 +72,7 @@
         </b-form-group>
 
         <b-form-group label="UN SDG:" label-for="un_sdg" class="my-1">
-            <small>A place name can be linked to a related UN Sutainable Development Goal</small>
+            <small>A place name can be linked to a related <a href="https://sdgs.un.org/goals">UN Sustainable Development Goal</a>.</small>
             <b-form-select id="un_sdg" class="form-select my-1" v-model.number="$v.form_data.un_sdg.$model" :options="lists.un_sdg" />
         </b-form-group>
 

--- a/scar-gazetteer/src/pages/InformationTerminology.vue
+++ b/scar-gazetteer/src/pages/InformationTerminology.vue
@@ -2,20 +2,13 @@
   <div class="span9">
     <h1>Terminology</h1>
     <p>
-      <b>Place ID</b> Sample text sample text sample text sample text sample
-      text sample text
+      <b>Name ID</b>: A unique number identifying a specific geographic feature. A feature can have multiple name IDs because it can have multiple names. Sometimes these names can be the same, indicating a nation has adopted the place names from another country. Sometimes they can be different due to countries adopting different names or the translation of a name from one language to another.
     </p>
     <p>
-      <b>Name ID</b> Sample text sample text sample text sample text sample text
-      sample text
+      <b>Place ID</b>: A unique number identifying a place name approved by a naming authority of a country.
     </p>
     <p>
-      <b>Relic</b> Sample text sample text sample text sample text sample text
-      sample text
-    </p>
-    <p>
-      <b>CGA</b> Sample text sample text sample text sample text sample text
-      sample text
+      <b>Relic</b>: A historical name or the name of a feature that no longer exists (for example, due to a changing coastline).
     </p>
   </div>
 </template>

--- a/scar-gazetteer/src/pages/InformationTerminology.vue
+++ b/scar-gazetteer/src/pages/InformationTerminology.vue
@@ -2,10 +2,10 @@
   <div class="span9">
     <h1>Terminology</h1>
     <p>
-      <b>Name ID</b>: A unique number identifying a specific geographic feature. A feature can have multiple name IDs because it can have multiple names. Sometimes these names can be the same, indicating a nation has adopted the place names from another country. Sometimes they can be different due to countries adopting different names or the translation of a name from one language to another.
+      <b>Name ID</b>: A unique number assigned to a specific place name entry. A single geographic feature may have multiple place name entries, as contributed by various nations. In some cases, these names are identical, indicating a nation has adopted a place name from another country. In other cases, these names differ, either because a country has translated the name into its own language or has assigned an entirely different one.
     </p>
     <p>
-      <b>Place ID</b>: A unique number identifying a place name approved by a naming authority of a country.
+      <b>Place ID</b>: A unique number identifying a specific geographic feature.
     </p>
     <p>
       <b>Relic</b>: A historical name or the name of a feature that no longer exists (for example, due to a changing coastline).

--- a/scar-gazetteer/src/pages/Main.vue
+++ b/scar-gazetteer/src/pages/Main.vue
@@ -2,10 +2,18 @@
     <b-container class="main-content">
         <h1>Welcome to the SCAR Composite Gazetteer of Antarctica</h1>
 
-        <p>The SCAR Composite Gazetteer of Antarctica (CGA) has been compiled over a period of {{ years }} years
+        <p>The SCAR Composite Gazetteer of Antarctica (CGA) is a composite or collection of all those names of geographic features. It includes the names of features south of 60°S, both terrestrial, near shore and under-ice.</p>
+
+        <p>It has been compiled over a period of {{ years }} years
             (commenced 1992) and consists of {{ name_count }} names that correspond to {{ feature_count }} features.
             The place names information has been submitted by the national names committees from {{ gazetteer_count }} countries.
         </p>
+
+        <p>The CGA is compiled purely for the convenience of the scientific community and has no legal authority or standing.</p>
+
+        <p>Since 2008, Italy and Australia jointly have managed the CGA, the former taking care of the editing, the latter maintaining the database and website. The SCAR <a href="https://scar.org/science/standing/scagi">Standing Committee on Antarctic Geographic Information (SCAGI)</a> coordinates the project.</p>
+
+        <p>For queries about the CGA email scar.cga@unisi.it</p>
 
         <ul class="unstyled">
             <li><b-icon-bar-chart style="text-align: center" /> <a href="/information/statistics"> View SCAR Gazetteer

--- a/scar-gazetteer/src/pages/NewPlaceName.vue
+++ b/scar-gazetteer/src/pages/NewPlaceName.vue
@@ -18,7 +18,7 @@ export default {
         return {
             form_data: {
                 "name_id": null,
-                "latitude": 0,
+                "latitude": -60,
                 "longitude": 0,
                 "altitude": null,
                 "feature_type_code": null,
@@ -47,6 +47,7 @@ export default {
                 "place_name_mapping": null,
                 "view_by_public_flag": true,
                 "un_sdg": 0,
+                "machine_translation": false,
             }
         }
     },

--- a/scar-gazetteer/src/pages/PlaceName.vue
+++ b/scar-gazetteer/src/pages/PlaceName.vue
@@ -1,7 +1,7 @@
 <template>
     <b-container class="place">
         <h1>{{ place.place_name_mapping }} <b-button :to="`/place-name/${place.name_id}/edit`"
-                v-if="$store.state.user.isAdmin">Edit</b-button></h1>
+                v-if="$store.state.user.isAdmin"><b-icon-pencil-square/> Edit</b-button></h1>
         <b-badge>Name ID: {{ place.name_id }}</b-badge> <b-badge>Place ID: {{ place.place_id }}</b-badge><br>
         <p v-if="place.feature_types">Feature Type: <a
                 :href="`https://data.aad.gov.au/feature-type/${place.feature_types.feature_type_code}`">{{

--- a/schema.sql
+++ b/schema.sql
@@ -97,7 +97,8 @@ CREATE TABLE gazetteer.place_names (
     country_code character varying(2),
     narrative_translation character varying(4000),
     machine_translation boolean,
-    un_sdg numeric(2,0)
+    un_sdg numeric(2,0),
+    pronunciation_audio_url character varying(500),
 );
 
 


### PR DESCRIPTION
- Updated text for home and terminology pages.
- Minor fix for place name form so that machine translation and UN SDG dropdowns are not initialised as blank.
- Pronunciation audio URL field added to place name table in schema.